### PR TITLE
Fix hook configurations

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -2,23 +2,17 @@
     name: "check file names"
     entry: check-file-names
     language: python
-    pass_filenames: true
-    always_run: true
     files: ^config/.*(.yaml|.yml|.json)$
     exclude: ^config/.*config(.yaml|.yml|.json)$
 -   id: check-stack-tags
     name: "check stack tags"
     entry: check-stack-tags
     language: python
-    pass_filenames: true
-    always_run: true
     files: ^config/.*(.yaml|.yml|.json)$
     exclude: ^config/.*config(.yaml|.yml|.json)$
 -   id: check-stack-names
     name: "check stack names"
     entry: check-stack-names
     language: python
-    pass_filenames: true
-    always_run: true
     files: ^config/.*(.yaml|.yml|.json)$
     exclude: ^config/.*config(.yaml|.yml|.json)$


### PR DESCRIPTION
`pass_filenames: true` is the default

`always_run: true` generally should not be set -- pre-commit
will pass filenames for changed things to the tool so it runs
selectively (otherwise when no files are changed the tool will
receive 0 filenames and probably do the wrong thing)