### PR TITLE
Handle loading files without file extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,15 @@ config's `stack_tags` key.
 Checks that a specific stack tag is assigned a valid value.
 
 
-| args    | Description                                                                                                                                                |
-|---------|------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| tag     | The tag to validate                                                                                                                                        |
-| file    | A json file with a list of valid tag values, can take a local or a url reference (i.e. https://raw.githubusercontent.com/acme/repo/master/valid_tags.json) |
-| exclude | A tag to exclude from the valid list of tags                                                                                                               |
+| args    | Description                                                           |
+|---------|-----------------------------------------------------------------------|
+| tag     | The tag to validate                                                   |
+| file    | A json file with a list of valid tag values                           |
+| exclude | A tag to exclude from the valid list of tags                          |
 
 __Notes__:
+ * The `file` can take a local (i.e. /home/project/valid_tags.json) or a url
+   reference (i.e. https://raw.githubusercontent.com/acme/repo/master/valid_tags.json)
  * The `file` and `exclude` args can be use multiple times
  * Do not quote tags containing spaces, i.e. `--exclude=Edu Outreach`
  * Example of a file containing valid tags values (valid_tags.json):

--- a/pre_commit_hooks/util.py
+++ b/pre_commit_hooks/util.py
@@ -36,52 +36,58 @@ def load_config(config_path: str) -> Any:
         return yaml.load(template.render(stack_group_config=''), Loader=yaml.FullLoader)
 
 
-def get_local_content(path: str) -> str:
+def get_local_content(path: str) -> list[str]:
     """
     Gets file contents from a file on the local machine
     :param path: The absolute path to a file
+    The path can reference a file containing yaml or json content.
+    The default is to assume json content.
     """
     try:
         filename, file_extension = os.path.splitext(path)
         with open(path, encoding='utf-8') as file:
-            content = file.read()
+            raw_content = file.read()
     except (OSError, TypeError) as e:
         raise e
 
-    if content:
-        if file_extension == '.json':
-            content = json.loads(content)
+    content = []
+    if raw_content:
         if file_extension == '.yaml' or file_extension == '.yml':
-            content = yaml.safe_load(content)
+            content = yaml.safe_load(raw_content)
+        else:
+            content = json.loads(raw_content)
 
     return content
 
 
-def get_url_content(path: str) -> str:
+def get_url_content(path: str) -> list[str]:
     """
     Gets file contents from a file at a URL location
     :param path: The URL reference to a file
+    The path can reference a file containing yaml or json content.
+    The default is to assume json content.
     """
     url = urlparse(path)
     filename, file_extension = os.path.splitext(url.path)
     try:
         response = requests.get(path)
-        content = response.text
+        raw_content = response.text
         if response.status_code != requests.codes.ok:
-            raise requests.exceptions.HTTPError(content)
+            raise requests.exceptions.HTTPError(raw_content)
     except requests.exceptions.RequestException as e:
         raise e
 
-    if content:
-        if file_extension == '.json':
-            content = json.loads(content)
+    content = []
+    if raw_content:
         if file_extension == '.yaml' or file_extension == '.yml':
-            content = yaml.safe_load(content)
+            content = yaml.safe_load(raw_content)
+        else:
+            content = json.loads(raw_content)
 
     return content
 
 
-def get_content(file: str) -> str:
+def get_content(file: str) -> list[str]:
 
     if file.startswith('http'):
         content = get_url_content(file)

--- a/testing/resources/check_stack_tag_values/stack_tags_from_http_match_tag_value.yaml
+++ b/testing/resources/check_stack_tag_values/stack_tags_from_http_match_tag_value.yaml
@@ -1,0 +1,5 @@
+template:
+  path: "template.yaml"
+stack_name: "not_valid"
+stack_tags:
+  color: "No Program / 000000"

--- a/testing/resources/check_stack_tag_values/stack_tags_from_http_non_matching_value.yaml
+++ b/testing/resources/check_stack_tag_values/stack_tags_from_http_non_matching_value.yaml
@@ -1,0 +1,5 @@
+template:
+  path: "template.yaml"
+stack_name: "not_valid"
+stack_tags:
+  color: "Bogus Program / 9999999"

--- a/testing/resources/check_stack_tag_values/tag_values1
+++ b/testing/resources/check_stack_tag_values/tag_values1
@@ -1,0 +1,5 @@
+[
+  "yellow",
+  "grey",
+  "black"
+]

--- a/tests/check_stack_tag_values_test.py
+++ b/tests/check_stack_tag_values_test.py
@@ -66,3 +66,15 @@ def test_stack_tags_tag_not_in_config_file():
     resource_path = get_resource_path(TEST_RESOURCES_DIR)
     files = [f'{resource_path}/stack_tags_tag_not_set.yaml']
     assert lint(files, 'color', [f'{resource_path}/tag_values1.json'], [])
+
+
+def test_stack_tags_key_from_http_exist_value_valid():
+    resource_path = get_resource_path(TEST_RESOURCES_DIR)
+    files = [f'{resource_path}/stack_tags_from_http_match_tag_value.yaml']
+    assert not lint(files, 'color', ['https://finops-api.sageit.org/tags'], [])
+
+
+def test_stack_tags_key_from_http_non_matching_value():
+    resource_path = get_resource_path(TEST_RESOURCES_DIR)
+    files = [f'{resource_path}/stack_tags_from_http_non_matching_value.yaml']
+    assert lint(files, 'color', ['https://finops-api.sageit.org/tags'], [])

--- a/tests/check_stack_tag_values_test.py
+++ b/tests/check_stack_tag_values_test.py
@@ -12,6 +12,12 @@ def test_stack_tags_key_exist_value_valid_single_file():
     assert not lint(files, 'color', [f'{resource_path}/tag_values1.json'], [])
 
 
+def test_stack_tags_key_exist_value_valid_no_file_extension():
+    resource_path = get_resource_path(TEST_RESOURCES_DIR)
+    files = [f'{resource_path}/stack_tags_match_tag_values1.yaml']
+    assert not lint(files, 'color', [f'{resource_path}/tag_values1'], [])
+
+
 def test_stack_tags_key_exist_value_valid_multiple_files():
     resource_path = get_resource_path(TEST_RESOURCES_DIR)
     files = [f'{resource_path}/stack_tags_match_tag_values2.yaml']


### PR DESCRIPTION
Handle the case when a `file` is set to a url endpoint or filename that does not
have an extension.

For example:
```
-  id: check-stack-tag-values
   args: [--tag=CostCenter, 
            --file=https://finance.acme.org/tags,
            --file=/home/acme/valid_tags]
```